### PR TITLE
Display a single item for suggestions from different dictionaries

### DIFF
--- a/Source/VSSpellChecker/MultiLanguageSpellingSuggestion.cs
+++ b/Source/VSSpellChecker/MultiLanguageSpellingSuggestion.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualStudio.SpellChecker
+{
+    /// <summary>
+    /// This represents a multi-language spelling suggestion that can be used to replace a misspelled word.
+    /// </summary>
+    public class MultiLanguageSpellingSuggestion : SpellingSuggestion
+    {
+        private IEnumerable<CultureInfo> cultures;
+        private string formattedText;
+
+        /// <summary>Multi-language suggestion constructor.</summary>
+        /// <param name="suggestion">The suggestion to replace misspelled word with</param>
+        /// <param name="cultures">The cultures from which the suggested word was chosen.</param>
+        public MultiLanguageSpellingSuggestion(IEnumerable<CultureInfo> cultures, string suggestion)
+            : base(cultures.First(), suggestion)
+        {
+            this.cultures = cultures;
+            this.formattedText = null;
+
+        }
+
+        /// <summary>Gets the culture information for the suggestion.</summary>
+        public IEnumerable<CultureInfo> Cultures
+        {
+            get
+            {
+                return cultures;
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String" /> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return formattedText ??
+                   (formattedText = FormatSuggestion(base.Suggestion, cultures));
+        }
+
+        /// <summary>Formats the suggestion to display the language to which it applies.</summary>
+        /// <param name="suggestion">The suggested word.</param>
+        /// <param name="cultures">The cultures to which the suggestion applies.</param>
+        public static string FormatSuggestion(string suggestion, IEnumerable<CultureInfo> cultures)
+        {
+            return string.Format("{0}\t\t({1})",
+                                 suggestion,
+                                 string.Join(" | ", cultures.Select(c => c.Name).ToArray()));
+        }
+    }
+}

--- a/Source/VSSpellChecker/MultiLanguageSpellingSuggestion.cs
+++ b/Source/VSSpellChecker/MultiLanguageSpellingSuggestion.cs
@@ -1,14 +1,31 @@
-﻿using System;
+﻿//===============================================================================================================
+// System  : Visual Studio Spell Checker Package
+// File    : MultiLanguageSpellingSuggestion.cs
+// Author  : Franz Alex Gaisie-Essilfie
+// Updated : 2015-08-22
+// Compiler: Microsoft Visual C#
+//
+// This file contains a class used to represent spelling suggestions from multiple dictionaries
+// that can be used to replace a misspelled word.
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy of the license should be
+// distributed with the code and can be found at the project website: https://github.com/EWSoftware/VSSpellChecker
+// This notice, the author's name, and all copyright notices must remain intact in all applications,
+// documentation, and source files.
+//
+//    Date     Who   Comments
+// ==============================================================================================================
+// 2015-08-22  FAGE  Created the code
+//===============================================================================================================
+
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VisualStudio.SpellChecker
 {
     /// <summary>
-    /// This represents a multi-language spelling suggestion that can be used to replace a misspelled word.
+    ///   This represents a multi-language spelling suggestion that can be used to replace a misspelled word.
     /// </summary>
     public class MultiLanguageSpellingSuggestion : SpellingSuggestion
     {
@@ -23,7 +40,6 @@ namespace VisualStudio.SpellChecker
         {
             this.cultures = cultures;
             this.formattedText = null;
-
         }
 
         /// <summary>Gets the culture information for the suggestion.</summary>
@@ -35,12 +51,8 @@ namespace VisualStudio.SpellChecker
             }
         }
 
-        /// <summary>
-        /// Returns a <see cref="System.String" /> that represents this instance.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="System.String" /> that represents this instance.
-        /// </returns>
+        /// <summary>Returns a <see cref="System.String" /> that represents this instance.</summary>
+        /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
         public override string ToString()
         {
             return formattedText ??

--- a/Source/VSSpellChecker/SmartTags/MultiLanguageSpellSmartTagAction.cs
+++ b/Source/VSSpellChecker/SmartTags/MultiLanguageSpellSmartTagAction.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.VisualStudio.Text;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace VisualStudio.SpellChecker.SmartTags
+{
+    /// <summary>Smart tag action for inserting multi-language spelling suggestions.</summary>
+    internal class MultiLanguageSpellSmartTagAction : SpellSmartTagAction
+    {
+        private CultureInfo[] _cultures;
+        private string _displayText;
+
+        /// <summary>Constructor for multi-language spelling suggestions smart tag actions.</summary>
+        /// <param name="trackingSpan">The tracking span.</param>
+        /// <param name="replaceWith">The suggestion to replace misspelled word with</param>
+        /// <param name="cultures">The cultures from which the suggested word was chosen.</param>
+        /// <param name="dictionary">The dictionary used to perform the Replace All action</param>
+        public MultiLanguageSpellSmartTagAction(ITrackingSpan trackingSpan,
+                                                SpellingSuggestion replaceWith,
+                                                IEnumerable<CultureInfo> cultures,
+                                                SpellingDictionary dictionary)
+            : base(trackingSpan, replaceWith, dictionary)
+        {
+            _cultures = cultures.ToArray();
+            _displayText = null;
+        }
+
+        /// <summary>Display text</summary>
+        public override string DisplayText
+        {
+            get
+            {
+                return (_displayText ?? FormatDisplayText());
+            }
+        }
+
+        /// <summary>Formats the display text.</summary>
+        private string FormatDisplayText()
+        {
+            _displayText = string.Format("{0}\t\t({1})",
+                                         base.DisplayText,
+                                         string.Join(" | ", _cultures.Select(c => c.Name).ToArray()));
+            return _displayText;
+        }
+    }
+}

--- a/Source/VSSpellChecker/SmartTags/MultiLanguageSpellSmartTagAction.cs
+++ b/Source/VSSpellChecker/SmartTags/MultiLanguageSpellSmartTagAction.cs
@@ -39,10 +39,7 @@ namespace VisualStudio.SpellChecker.SmartTags
         /// <summary>Formats the display text.</summary>
         private string FormatDisplayText()
         {
-            displayText = string.Format("{0}\t\t({1})",
-                                         base.DisplayText,
-                                         string.Join(" | ", cultures.Select(c => c.Name).ToArray()));
-            return displayText;
+            return (displayText = MultiLanguageSpellingSuggestion.FormatSuggestion(base.DisplayText, cultures));
         }
     }
 }

--- a/Source/VSSpellChecker/SmartTags/MultiLanguageSpellSmartTagAction.cs
+++ b/Source/VSSpellChecker/SmartTags/MultiLanguageSpellSmartTagAction.cs
@@ -1,16 +1,16 @@
-﻿using Microsoft.VisualStudio.Text;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+
+using Microsoft.VisualStudio.Text;
 
 namespace VisualStudio.SpellChecker.SmartTags
 {
     /// <summary>Smart tag action for inserting multi-language spelling suggestions.</summary>
     internal class MultiLanguageSpellSmartTagAction : SpellSmartTagAction
     {
-        private CultureInfo[] _cultures;
-        private string _displayText;
+        private CultureInfo[] cultures;
+        private string displayText;
 
         /// <summary>Constructor for multi-language spelling suggestions smart tag actions.</summary>
         /// <param name="trackingSpan">The tracking span.</param>
@@ -23,8 +23,8 @@ namespace VisualStudio.SpellChecker.SmartTags
                                                 SpellingDictionary dictionary)
             : base(trackingSpan, replaceWith, dictionary)
         {
-            _cultures = cultures.ToArray();
-            _displayText = null;
+            this.cultures = cultures.ToArray();
+            this.displayText = null;
         }
 
         /// <summary>Display text</summary>
@@ -32,17 +32,17 @@ namespace VisualStudio.SpellChecker.SmartTags
         {
             get
             {
-                return (_displayText ?? FormatDisplayText());
+                return (displayText ?? FormatDisplayText());
             }
         }
 
         /// <summary>Formats the display text.</summary>
         private string FormatDisplayText()
         {
-            _displayText = string.Format("{0}\t\t({1})",
+            displayText = string.Format("{0}\t\t({1})",
                                          base.DisplayText,
-                                         string.Join(" | ", _cultures.Select(c => c.Name).ToArray()));
-            return _displayText;
+                                         string.Join(" | ", cultures.Select(c => c.Name).ToArray()));
+            return displayText;
         }
     }
 }

--- a/Source/VSSpellChecker/SmartTags/MultiLanguageSpellSmartTagAction.cs
+++ b/Source/VSSpellChecker/SmartTags/MultiLanguageSpellSmartTagAction.cs
@@ -1,4 +1,24 @@
-﻿using System.Collections.Generic;
+﻿//===============================================================================================================
+// System  : Visual Studio Spell Checker Package
+// File    : MultiLanguageSpellSmartTagAction.cs
+// Author  : Franz Alex Gaisie-Essilfie
+// Updated : 2015-08-22
+// Compiler: Microsoft Visual C#
+//
+// This file contains a class used to provide a smart tag action for inserting multi-language spelling suggestions
+//
+// This code is published under the Microsoft Public License (Ms-PL).  A copy of the license should be
+// distributed with the code and can be found at the project website: https://github.com/EWSoftware/VSSpellChecker
+// This notice, the author's name, and all copyright notices must remain intact in all applications,
+// documentation, and source files.
+//
+//    Date     Who   Comments
+// ==============================================================================================================
+// 2015-08-18  FAGE  Created the code
+// 2015-08-22  FAGE  Use same suggestion formatter as MultiLanguageSpellingSuggestion.cs
+//===============================================================================================================
+
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
@@ -32,14 +52,9 @@ namespace VisualStudio.SpellChecker.SmartTags
         {
             get
             {
-                return (displayText ?? FormatDisplayText());
+                return displayText ??
+                      (displayText = MultiLanguageSpellingSuggestion.FormatSuggestion(base.DisplayText, cultures));
             }
-        }
-
-        /// <summary>Formats the display text.</summary>
-        private string FormatDisplayText()
-        {
-            return (displayText = MultiLanguageSpellingSuggestion.FormatSuggestion(base.DisplayText, cultures));
         }
     }
 }

--- a/Source/VSSpellChecker/SmartTags/SpellSmartTagAction.cs
+++ b/Source/VSSpellChecker/SmartTags/SpellSmartTagAction.cs
@@ -83,7 +83,7 @@ namespace VisualStudio.SpellChecker.SmartTags
         /// </summary>
         public void Invoke()
         {
-            if (dictionary != null && Keyboard.Modifiers == ModifierKeys.Control)
+            if(dictionary != null && Keyboard.Modifiers == ModifierKeys.Control)
                 dictionary.ReplaceAllOccurrences(span.GetText(span.TextBuffer.CurrentSnapshot), replaceWith);
             else
                 span.TextBuffer.Replace(span.GetSpan(span.TextBuffer.CurrentSnapshot), replaceWith.Suggestion);

--- a/Source/VSSpellChecker/SmartTags/SpellSmartTagAction.cs
+++ b/Source/VSSpellChecker/SmartTags/SpellSmartTagAction.cs
@@ -65,7 +65,7 @@ namespace VisualStudio.SpellChecker.SmartTags
         /// <summary>
         /// Display text
         /// </summary>
-        public string DisplayText
+        public virtual string DisplayText
         {
             get { return replaceWith.Suggestion; }
         }
@@ -83,7 +83,7 @@ namespace VisualStudio.SpellChecker.SmartTags
         /// </summary>
         public void Invoke()
         {
-            if(dictionary != null && Keyboard.Modifiers == ModifierKeys.Control)
+            if (dictionary != null && Keyboard.Modifiers == ModifierKeys.Control)
                 dictionary.ReplaceAllOccurrences(span.GetText(span.TextBuffer.CurrentSnapshot), replaceWith);
             else
                 span.TextBuffer.Replace(span.GetSpan(span.TextBuffer.CurrentSnapshot), replaceWith.Suggestion);

--- a/Source/VSSpellChecker/SmartTags/SpellSmartTagger.cs
+++ b/Source/VSSpellChecker/SmartTags/SpellSmartTagger.cs
@@ -1,7 +1,7 @@
 //===============================================================================================================
 // System  : Visual Studio Spell Checker Package
 // File    : SpellSmartTagger.cs
-// Authors : Noah Richards, Roman Golovin, Michael Lehenbauer, Eric Woodruff
+// Authors : Noah Richards, Roman Golovin, Michael Lehenbauer, Eric Woodruff, Franz Alex Gaisie-Essilfie
 // Updated : 08/02/2015
 // Note    : Copyright 2010-2015, Microsoft Corporation, All rights reserved
 //           Portions Copyright 2013-2015, Eric Woodruff, All rights reserved
@@ -14,17 +14,18 @@
 // This notice, the author's name, and all copyright notices must remain intact in all applications,
 // documentation, and source files.
 //
-//    Date     Who  Comments
+//    Date     Who   Comments
 // ==============================================================================================================
-// 04/14/2013  EFW  Imported the code into the project
-// 04/26/2013  EFW  Added support for disabling spell checking as you type
-// 05/02/2013  EFW  Added support for Replace All
-// 05/31/2013  EFW  Added support for Ignore Once
-// 06/06/2014  EFW  Added support for doubled word smart tags
-// 06/20/2014  EFW  Added support for use in VS 2013 Peek Definition windows
-// 02/28/2015  EFW  Added support for code analysis dictionary options
-// 07/28/2015  EFW  Added support for culture information in the spelling suggestions
-// 08/01/2015  EFW  Added support for multiple dictionary languages
+// 04/14/2013  EFW   Imported the code into the project
+// 04/26/2013  EFW   Added support for disabling spell checking as you type
+// 05/02/2013  EFW   Added support for Replace All
+// 05/31/2013  EFW   Added support for Ignore Once
+// 06/06/2014  EFW   Added support for doubled word smart tags
+// 06/20/2014  EFW   Added support for use in VS 2013 Peek Definition windows
+// 02/28/2015  EFW   Added support for code analysis dictionary options
+// 07/28/2015  EFW   Added support for culture information in the spelling suggestions
+// 08/01/2015  EFW   Added support for multiple dictionary languages
+// 08/18/2015  FAGE  Grouping of multi-language suggestions by word
 //===============================================================================================================
 
 using System;

--- a/Source/VSSpellChecker/SmartTags/SpellSmartTagger.cs
+++ b/Source/VSSpellChecker/SmartTags/SpellSmartTagger.cs
@@ -89,7 +89,7 @@ namespace VisualStudio.SpellChecker.SmartTags
             {
                 // If this view isn't editable, then there isn't a good reason to be showing these.  Also,
                 // make sure we are only tagging the top buffer.
-                if (textView == null || buffer == null || spellingService == null ||
+                if(textView == null || buffer == null || spellingService == null ||
                   textView.TextBuffer != buffer || !textView.Roles.Contains(PredefinedTextViewRoles.Editable) ||
                   (!textView.Roles.Contains(PredefinedTextViewRoles.PrimaryDocument) &&
                   !textView.Roles.Contains(Utility.EmbeddedPeekTextView)))
@@ -100,7 +100,7 @@ namespace VisualStudio.SpellChecker.SmartTags
                 // Getting the dictionary determines if spell checking is enabled for this file
                 var dictionary = spellingService.GetDictionary(buffer);
 
-                if (dictionary == null)
+                if(dictionary == null)
                     return null;
 
                 return new SpellSmartTagger(buffer, dictionary,
@@ -125,9 +125,10 @@ namespace VisualStudio.SpellChecker.SmartTags
             this.dictionary = dictionary;
             this.misspellingAggregator = misspellingAggregator;
 
-            this.misspellingAggregator.TagsChanged += (sender, args) => {
-                if (!this.disposed)
-                    foreach (var span in args.Span.GetSpans(this.buffer))
+            this.misspellingAggregator.TagsChanged += (sender, args) =>
+            {
+                if(!this.disposed)
+                    foreach(var span in args.Span.GetSpans(this.buffer))
                         RaiseTagsChangedEvent(span);
             };
         }
@@ -143,21 +144,21 @@ namespace VisualStudio.SpellChecker.SmartTags
         /// <returns>Squiggle tags in the provided spans</returns>
         public IEnumerable<ITagSpan<SpellSmartTag>> GetTags(NormalizedSnapshotSpanCollection spans)
         {
-            if (spans.Count == 0 || disposed)
+            if(spans.Count == 0 || disposed)
                 yield break;
 
             ITextSnapshot snapshot = spans[0].Snapshot;
 
-            foreach (var misspelling in misspellingAggregator.GetTags(spans))
+            foreach(var misspelling in misspellingAggregator.GetTags(spans))
             {
                 var misspellingSpans = misspelling.Span.GetSpans(snapshot);
 
-                if (misspellingSpans.Count != 1)
+                if(misspellingSpans.Count != 1)
                     continue;
 
                 SnapshotSpan errorSpan = misspellingSpans[0];
 
-                if (misspelling.Tag.MisspellingType != MisspellingType.DoubledWord)
+                if(misspelling.Tag.MisspellingType != MisspellingType.DoubledWord)
                 {
                     yield return new TagSpan<SpellSmartTag>(errorSpan, new SpellSmartTag(
                         GetMisspellingSmartTagActions(errorSpan, misspelling.Tag.MisspellingType,
@@ -190,9 +191,9 @@ namespace VisualStudio.SpellChecker.SmartTags
 
         private void Dispose(bool disposing)
         {
-            if (!disposed)
+            if(!disposed)
             {
-                if (disposing)
+                if(disposing)
                 {
                     misspellingAggregator.Dispose();
                     misspellingAggregator = null;
@@ -222,7 +223,7 @@ namespace VisualStudio.SpellChecker.SmartTags
             ITrackingSpan trackingSpan = errorSpan.Snapshot.CreateTrackingSpan(errorSpan,
                 SpanTrackingMode.EdgeExclusive);
 
-            if (dictionary.DictionaryCount > 1)
+            if(dictionary.DictionaryCount > 1)
             {
                 // merge the same words from different dictionaries
                 var words = from word in suggestions
@@ -239,13 +240,13 @@ namespace VisualStudio.SpellChecker.SmartTags
             else
             {
                 // Add spelling suggestions grouped by language when appropriate
-                foreach (var word in suggestions)
+                foreach(var word in suggestions)
                 {
-                    if (!word.IsGroupHeader)
+                    if(!word.IsGroupHeader)
                         actions.Add(new SpellSmartTagAction(trackingSpan, word, dictionary));
                     else
                     {
-                        if (actions.Count != 0)
+                        if(actions.Count != 0)
                         {
                             smartTagSets.Add(new SmartTagActionSet(actions.AsReadOnly()));
                             actions = new List<ISmartTagAction>();
@@ -257,10 +258,10 @@ namespace VisualStudio.SpellChecker.SmartTags
                 }
             }
 
-            if (actions.Count != 0)
+            if(actions.Count != 0)
                 smartTagSets.Add(new SmartTagActionSet(actions.AsReadOnly()));
 
-            if (smartTagSets.Count != 0)
+            if(smartTagSets.Count != 0)
             {
                 // This acts as a place holder to tell the user to hold the Ctrl key down to replace all
                 // occurrences of the selected word.
@@ -280,11 +281,11 @@ namespace VisualStudio.SpellChecker.SmartTags
 
             smartTagSets.Add(new SmartTagActionSet(actions.AsReadOnly()));
 
-            if (misspellingType == MisspellingType.MisspelledWord)
+            if(misspellingType == MisspellingType.MisspelledWord)
             {
                 actions = new List<ISmartTagAction>();
 
-                foreach (var d in dictionary.Dictionaries)
+                foreach(var d in dictionary.Dictionaries)
                     actions.Add(new SpellDictionarySmartTagAction(trackingSpan, dictionary,
                         "Add to Dictionary", DictionaryAction.AddWord, d.Culture));
 
@@ -332,7 +333,7 @@ namespace VisualStudio.SpellChecker.SmartTags
         {
             EventHandler<SnapshotSpanEventArgs> handler = this.TagsChanged;
 
-            if (handler != null)
+            if(handler != null)
                 handler(this, new SnapshotSpanEventArgs(subjectSpan));
         }
         #endregion

--- a/Source/VSSpellChecker/SmartTags/SpellSmartTagger.cs
+++ b/Source/VSSpellChecker/SmartTags/SpellSmartTagger.cs
@@ -89,7 +89,7 @@ namespace VisualStudio.SpellChecker.SmartTags
             {
                 // If this view isn't editable, then there isn't a good reason to be showing these.  Also,
                 // make sure we are only tagging the top buffer.
-                if(textView == null || buffer == null || spellingService == null ||
+                if (textView == null || buffer == null || spellingService == null ||
                   textView.TextBuffer != buffer || !textView.Roles.Contains(PredefinedTextViewRoles.Editable) ||
                   (!textView.Roles.Contains(PredefinedTextViewRoles.PrimaryDocument) &&
                   !textView.Roles.Contains(Utility.EmbeddedPeekTextView)))
@@ -100,7 +100,7 @@ namespace VisualStudio.SpellChecker.SmartTags
                 // Getting the dictionary determines if spell checking is enabled for this file
                 var dictionary = spellingService.GetDictionary(buffer);
 
-                if(dictionary == null)
+                if (dictionary == null)
                     return null;
 
                 return new SpellSmartTagger(buffer, dictionary,
@@ -125,10 +125,9 @@ namespace VisualStudio.SpellChecker.SmartTags
             this.dictionary = dictionary;
             this.misspellingAggregator = misspellingAggregator;
 
-            this.misspellingAggregator.TagsChanged += (sender, args) =>
-            {
-                if(!this.disposed)
-                    foreach(var span in args.Span.GetSpans(this.buffer))
+            this.misspellingAggregator.TagsChanged += (sender, args) => {
+                if (!this.disposed)
+                    foreach (var span in args.Span.GetSpans(this.buffer))
                         RaiseTagsChangedEvent(span);
             };
         }
@@ -144,21 +143,21 @@ namespace VisualStudio.SpellChecker.SmartTags
         /// <returns>Squiggle tags in the provided spans</returns>
         public IEnumerable<ITagSpan<SpellSmartTag>> GetTags(NormalizedSnapshotSpanCollection spans)
         {
-            if(spans.Count == 0 || disposed)
+            if (spans.Count == 0 || disposed)
                 yield break;
 
             ITextSnapshot snapshot = spans[0].Snapshot;
 
-            foreach(var misspelling in misspellingAggregator.GetTags(spans))
+            foreach (var misspelling in misspellingAggregator.GetTags(spans))
             {
                 var misspellingSpans = misspelling.Span.GetSpans(snapshot);
 
-                if(misspellingSpans.Count != 1)
+                if (misspellingSpans.Count != 1)
                     continue;
 
                 SnapshotSpan errorSpan = misspellingSpans[0];
 
-                if(misspelling.Tag.MisspellingType != MisspellingType.DoubledWord)
+                if (misspelling.Tag.MisspellingType != MisspellingType.DoubledWord)
                 {
                     yield return new TagSpan<SpellSmartTag>(errorSpan, new SpellSmartTag(
                         GetMisspellingSmartTagActions(errorSpan, misspelling.Tag.MisspellingType,
@@ -191,9 +190,9 @@ namespace VisualStudio.SpellChecker.SmartTags
 
         private void Dispose(bool disposing)
         {
-            if(!disposed)
+            if (!disposed)
             {
-                if(disposing)
+                if (disposing)
                 {
                     misspellingAggregator.Dispose();
                     misspellingAggregator = null;
@@ -223,28 +222,22 @@ namespace VisualStudio.SpellChecker.SmartTags
             ITrackingSpan trackingSpan = errorSpan.Snapshot.CreateTrackingSpan(errorSpan,
                 SpanTrackingMode.EdgeExclusive);
 
-            // Add spelling suggestions grouped by language when appropriate
-            foreach(var word in suggestions)
-            {
-                if(!word.IsGroupHeader)
-                    actions.Add(new SpellSmartTagAction(trackingSpan, word, dictionary));
-                else
-                {
-                    if(actions.Count != 0)
-                    {
-                        smartTagSets.Add(new SmartTagActionSet(actions.AsReadOnly()));
-                        actions = new List<ISmartTagAction>();
-                    }
+            // merge the same words from different dictionaries
+            var words = from word in suggestions
+                        where !word.IsGroupHeader
+                        group word by word.Suggestion into grp
+                        select new MultiLanguageSpellSmartTagAction(trackingSpan,
+                                                                    grp.First(),
+                                                                    grp.Select(w => w.Culture),
+                                                                    dictionary);
 
-                    actions.Add(new LabelSmartTagAction(String.Format(CultureInfo.InvariantCulture, "{0} ({1})",
-                        word.Culture.EnglishName, word.Culture.Name)));
-                }
-            }
+            // workaround for the inability to convert implicitly from MultiLanguageSpellSmartTagAction
+            actions.AddRange(words);
 
-            if(actions.Count != 0)
+            if (actions.Count != 0)
                 smartTagSets.Add(new SmartTagActionSet(actions.AsReadOnly()));
 
-            if(smartTagSets.Count != 0)
+            if (smartTagSets.Count != 0)
             {
                 // This acts as a place holder to tell the user to hold the Ctrl key down to replace all
                 // occurrences of the selected word.
@@ -264,11 +257,11 @@ namespace VisualStudio.SpellChecker.SmartTags
 
             smartTagSets.Add(new SmartTagActionSet(actions.AsReadOnly()));
 
-            if(misspellingType == MisspellingType.MisspelledWord)
+            if (misspellingType == MisspellingType.MisspelledWord)
             {
                 actions = new List<ISmartTagAction>();
 
-                foreach(var d in dictionary.Dictionaries)
+                foreach (var d in dictionary.Dictionaries)
                     actions.Add(new SpellDictionarySmartTagAction(trackingSpan, dictionary,
                         "Add to Dictionary", DictionaryAction.AddWord, d.Culture));
 
@@ -316,7 +309,7 @@ namespace VisualStudio.SpellChecker.SmartTags
         {
             EventHandler<SnapshotSpanEventArgs> handler = this.TagsChanged;
 
-            if(handler != null)
+            if (handler != null)
                 handler(this, new SnapshotSpanEventArgs(subjectSpan));
         }
         #endregion

--- a/Source/VSSpellChecker/ToolWindows/InteractiveSpellCheckControl.xaml.cs
+++ b/Source/VSSpellChecker/ToolWindows/InteractiveSpellCheckControl.xaml.cs
@@ -243,7 +243,7 @@ namespace VisualStudio.SpellChecker.ToolWindows
                         foreach(var s in suggestions)
                             lbSuggestions.Items.Add(s);
 
-                        lbSuggestions.SelectedIndex = issue.Suggestions.First().IsGroupHeader ? 1 : 0;
+                        lbSuggestions.SelectedIndex = 0;
                     }
                     else
                         lbSuggestions.Items.Add("(No suggestions)");

--- a/Source/VSSpellChecker/ToolWindows/InteractiveSpellCheckControl.xaml.cs
+++ b/Source/VSSpellChecker/ToolWindows/InteractiveSpellCheckControl.xaml.cs
@@ -93,7 +93,7 @@ namespace VisualStudio.SpellChecker.ToolWindows
 
                             if(outliningManagerService != null)
                                 outliningManager = outliningManagerService.GetOutliningManager(currentTextView);
-                        } 
+                        }
 
                         tagger_TagsChanged(this, null);
 
@@ -225,7 +225,22 @@ namespace VisualStudio.SpellChecker.ToolWindows
                         btnReplace.IsEnabled = btnReplaceAll.IsEnabled = true;
                         btnAddWord.IsEnabled = (issue.MisspellingType == MisspellingType.MisspelledWord);
 
-                        foreach(var s in issue.Suggestions)
+                        IEnumerable<SpellingSuggestion> suggestions;
+
+                        // group suggestions by suggestion (word) if there are multiple dictionaries
+                        if(currentTagger.Dictionary.DictionaryCount > 1)
+                        {
+                            suggestions = from word in issue.Suggestions
+                                          where !word.IsGroupHeader
+                                          group word by word.Suggestion into grp
+                                          select new MultiLanguageSpellingSuggestion(grp.Select(w => w.Culture), grp.Key);
+                        }
+                        else
+                        {
+                            suggestions = issue.Suggestions;
+                        }
+
+                        foreach(var s in suggestions)
                             lbSuggestions.Items.Add(s);
 
                         lbSuggestions.SelectedIndex = issue.Suggestions.First().IsGroupHeader ? 1 : 0;

--- a/Source/VSSpellChecker/ToolWindows/InteractiveSpellCheckControl.xaml.cs
+++ b/Source/VSSpellChecker/ToolWindows/InteractiveSpellCheckControl.xaml.cs
@@ -1,7 +1,7 @@
 //===============================================================================================================
 // System  : Visual Studio Spell Checker Package
 // File    : InteractiveSpellCheckControl.cs
-// Author  : Eric Woodruff  (Eric@EWoodruff.us)
+// Authors : Eric Woodruff  (Eric@EWoodruff.us), Franz Alex Gaisie-Essilfie
 // Updated : 08/05/2015
 // Note    : Copyright 2013-2015, Eric Woodruff, All rights reserved
 // Compiler: Microsoft Visual C#
@@ -13,11 +13,12 @@
 // This notice, the author's name, and all copyright notices must remain intact in all applications,
 // documentation, and source files.
 //
-//    Date     Who  Comments
+//    Date     Who   Comments
 // ==============================================================================================================
-// 05/28/2013  EFW  Created the code
-// 02/28/2015  EFW  Added support for code analysis dictionary options
-// 07/28/2015  EFW  Added support for culture information and multiple dictionaries
+// 05/28/2013  EFW   Created the code
+// 02/28/2015  EFW   Added support for code analysis dictionary options
+// 07/28/2015  EFW   Added support for culture information and multiple dictionaries
+// 08/22/2015  FAGE  Grouping of multi-language suggestions by word
 //===============================================================================================================
 
 using System;

--- a/Source/VSSpellChecker/VSSpellChecker.csproj
+++ b/Source/VSSpellChecker/VSSpellChecker.csproj
@@ -92,6 +92,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Guids.cs">
     </Compile>
+    <Compile Include="MultiLanguageSpellingSuggestion.cs" />
     <Compile Include="PkgCmdID.cs">
     </Compile>
     <Compile Include="GlobalDictionary.cs" />

--- a/Source/VSSpellChecker/VSSpellChecker.csproj
+++ b/Source/VSSpellChecker/VSSpellChecker.csproj
@@ -100,6 +100,7 @@
     <Compile Include="SmartTags\DictionaryAction.cs" />
     <Compile Include="SmartTags\DoubledWordSmartTagAction.cs" />
     <Compile Include="SmartTags\LabelSmartTagAction.cs" />
+    <Compile Include="SmartTags\MultiLanguageSpellSmartTagAction.cs" />
     <Compile Include="SpellingEventArgs.cs" />
     <Compile Include="SpellingServiceProxy.cs" />
     <Compile Include="SpellingSuggestion.cs" />


### PR DESCRIPTION
Applied a fix to display a single item for suggestions of the same word coming from different dictionaries. The screenshot below shows the result when two or more languages are selected.

![Single item for multi-language suggestions](https://cloud.githubusercontent.com/assets/7560066/9334061/61e5384c-45bc-11e5-9238-a8267dd115d1.png "Single item for multi-language suggestions")


This pull request fixes issue #49 .