### PR TITLE
Removed redundant dependency

### DIFF
--- a/Source/VSSpellChecker/source.extension.vsixmanifest
+++ b/Source/VSSpellChecker/source.extension.vsixmanifest
@@ -17,7 +17,6 @@
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
-        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" Version="[15.0,)" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
This is important for VS 2019 support. The dependency on MPF has actually not been required since before Visual Studio 2010