### PR TITLE
Allow "Wpf textbox" flag to be turned off

### DIFF
--- a/Source/VSSpellCheckerShared/Configuration/SpellCheckerConfiguration.cs
+++ b/Source/VSSpellCheckerShared/Configuration/SpellCheckerConfiguration.cs
@@ -546,10 +546,10 @@ namespace VisualStudio.SpellChecker.Configuration
                 else
                 {
                     // These only apply to the global configuration
+                    this.EnableWpfTextBoxSpellChecking = configuration.ToBoolean(PropertyNames.EnableWpfTextBoxSpellChecking);
+
                     if(configuration.HasProperty(PropertyNames.VisualStudioIdExclusions))
                     {
-                        this.EnableWpfTextBoxSpellChecking = configuration.ToBoolean(PropertyNames.EnableWpfTextBoxSpellChecking);
-
                         visualStudioExclusions = new List<Regex>(configuration.ToRegexes(PropertyNames.VisualStudioIdExclusions,
                             PropertyNames.VisualStudioIdExclusionItem));
                     }


### PR DESCRIPTION
When the WpfTextBoxSpellChecker flag is turned off (the **Visual Studio WPF Text Boxes** option in the **Global Spell Checker Configuration Settings**), the spell checker is still active in Visual Studio's WPF textboxes.